### PR TITLE
Ignore `core.py` and `core_test.py`

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -2,7 +2,7 @@
   "template": "https://github.com/hypothesis/cookiecutters",
   "checkout": null,
   "directory": "pypackage",
-  "ignore": [],
+  "ignore": ["src/data_tasks/core.py", "tests/unit/data_tasks/core_test.py"],
   "extra_context": {
     "name": "data-tasks",
     "package_name": "data_tasks",


### PR DESCRIPTION
So that `make template` doesn't re-add these files. If you don't want these files you have to add them to the ignore list.