### PR TITLE
Add psycopg2 and use Postgres instead of SQLite

### DIFF
--- a/.cookiecutter/includes/setuptools/install_requires
+++ b/.cookiecutter/includes/setuptools/install_requires
@@ -1,5 +1,4 @@
 importlib_resources
 jinja2
-SQLAlchemy
 sqlparse
 tabulate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
         image: postgres:11.5-alpine
         ports:
         - 5439:5432
-    env:
-      TEST_DATABASE_URL: postgresql://postgres@localhost:5439/data_tasks_test
     strategy:
       matrix:
         python-version: ['3.10', '3.9', '3.8', '3.7']
@@ -76,8 +74,6 @@ jobs:
         image: postgres:11.5-alpine
         ports:
         - 5439:5432
-    env:
-      TEST_DATABASE_URL: postgresql://postgres@localhost:5439/data_tasks_test
     strategy:
       matrix:
         python-version: ['3.10', '3.9', '3.8', '3.7']

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,10 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     importlib_metadata;python_version<"3.8."
+    sqlalchemy
+    psycopg2
     importlib_resources
     jinja2
-    SQLAlchemy
     sqlparse
     tabulate
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,9 @@ import os
 import pytest
 import sqlalchemy
 
-TEST_SETTINGS = {"database_url": os.environ.get("TEST_DATABASE_URL", "sqlite://")}
+TEST_SETTINGS = {
+    "database_url": os.environ["TEST_DATABASE_URL"],
+}
 
 
 @pytest.fixture(scope="session")

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ skip_install =
 setenv =
     PYTHONUNBUFFERED = 1
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
+    dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:5439/postgres}
+    tests,functests: TEST_DATABASE_URL = {env:TEST_DATABASE_URL:postgresql://postgres@localhost:5439/data_tasks_test}
 passenv =
     HOME
     PYTEST_ADDOPTS


### PR DESCRIPTION
Apply changes from the cookiecutter in
https://github.com/hypothesis/cookiecutters/pull/103 that add the `psycopg2` dependency and the `DATABASE_URL` and `TEST_DATABASE_URL` envvars, setting them to the project's Postgres DB instead of an SQLite DB.